### PR TITLE
Add method to pass ILogger<UpgradeEngine> directly

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,6 +4,11 @@
 
 
 ## To Use
+
+The two ways to use this extension are described below. Both have the same result, but are different ways to pass in the logger.
+
+### Using Service Provider
+
 1. Add `using DbUp.Extensions.Logging;`
 2. Call `AddLoggerFromServiceProvider()` on the `UpgradeEngineBuilder` passing `IServiceProvider` as an argument. Check the example below. 
 
@@ -12,6 +17,19 @@
         .SqlDatabase(con)
         .WithScriptsEmbeddedInAssembly(Assembly.GetExecutingAssembly())
         .AddLoggerFromServiceProvider(serviceProvider)
+        .Build();
+```
+
+### Using Logger
+
+1. Add `using DbUp.Extensions.Logging;`
+2. Call `AddLogger()` on the `UpgradeEngineBuilder` passing `ILogger<UpgradeEngine>` as an argument. Check the example below. 
+
+```csharp
+    DeployChanges.To
+        .SqlDatabase(con)
+        .WithScriptsEmbeddedInAssembly(Assembly.GetExecutingAssembly())
+        .AddLogger(logger)
         .Build();
 ```
 

--- a/src/DbUp.Extensions.Microsoft.Logging/DbUp.Extensions.Microsoft.Logging.csproj
+++ b/src/DbUp.Extensions.Microsoft.Logging/DbUp.Extensions.Microsoft.Logging.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>Latest</LangVersion>
     <IsPackable>true</IsPackable>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <PackageTags>DbUp;Db Up;Db;Logging;Logger;Log;</PackageTags>
     <Authors>Ibrahim Abdelkareem</Authors>
     <PackageProjectUrl>https://github.com/iabdelkareem/dbup-extensions.git</PackageProjectUrl>

--- a/src/DbUp.Extensions.Microsoft.Logging/DbUp.Extensions.Microsoft.Logging.csproj
+++ b/src/DbUp.Extensions.Microsoft.Logging/DbUp.Extensions.Microsoft.Logging.csproj
@@ -17,7 +17,12 @@
     <Description>
       This package extends DbUp logging by enabling using Microsoft.Extensions.Logging.ILogger that's registered in Microsoft Dependency Injection (i.e., IServiceProvider).
     </Description>
+    <PackageReadmeFile>readme.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\readme.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="dbup-core" Version="4.5.0" />

--- a/src/DbUp.Extensions.Microsoft.Logging/DbUp.Extensions.Microsoft.Logging.csproj
+++ b/src/DbUp.Extensions.Microsoft.Logging/DbUp.Extensions.Microsoft.Logging.csproj
@@ -17,11 +17,11 @@
     <Description>
       This package extends DbUp logging by enabling using Microsoft.Extensions.Logging.ILogger that's registered in Microsoft Dependency Injection (i.e., IServiceProvider).
     </Description>
-    <PackageReadmeFile>readme.md</PackageReadmeFile>
+    <PackageReadmeFile>Readme.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\readme.md" Pack="true" PackagePath="\" />
+    <None Include="..\..\Readme.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DbUp.Extensions.Microsoft.Logging/UpgradeEngineBuilderExtensions.cs
+++ b/src/DbUp.Extensions.Microsoft.Logging/UpgradeEngineBuilderExtensions.cs
@@ -10,6 +10,11 @@ namespace DbUp.Extensions.Logging
         public static UpgradeEngineBuilder AddLoggerFromServiceProvider(this UpgradeEngineBuilder upgradeEngineBuilder, IServiceProvider serviceProvider)
         {
             var logger = (ILogger<UpgradeEngine>) serviceProvider.GetService(typeof(ILogger<UpgradeEngine>));
+            return upgradeEngineBuilder.AddLogger(logger);
+        }
+
+        public static UpgradeEngineBuilder AddLogger(this UpgradeEngineBuilder upgradeEngineBuilder, ILogger<UpgradeEngine> logger)
+        {
             upgradeEngineBuilder.LogTo(new UpgradeLogWrapper(logger));
             return upgradeEngineBuilder;
         }

--- a/test/DbUp.Extensions.Microsoft.Logging.Tests/DbUp.Extensions.Microsoft.Logging.Tests.csproj
+++ b/test/DbUp.Extensions.Microsoft.Logging.Tests/DbUp.Extensions.Microsoft.Logging.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
I would find it useful in some scenarios to be able to pass the logger in directly instead of having to use the service provider. This change just adds and extension method to allow that. I also updated the test project to use .net 6 as 5 is out of support now, updated the readme and updated the project file to include the readme in the nuget package.